### PR TITLE
Update go.mod and number formatting, also add missing columns

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mailru/easyjson v0.7.1 // indirect
 	github.com/mattn/go-colorable v0.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
-	github.com/olivere/elastic v6.2.33+incompatible
+	github.com/olivere/elastic v6.2.33+incompatible // indirect
 	github.com/olivere/elastic/v7 v7.0.19
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/testify v1.6.1 // indirect

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/cheggaaa/pb"
-	"github.com/jawher/mow.cli"
+	cli "github.com/jawher/mow.cli"
 	"github.com/olivere/elastic/v7"
 	"golang.org/x/sync/errgroup"
 )
@@ -184,20 +184,30 @@ func main() {
 					for _, field := range *configFields {
 						if val, ok := document[field]; ok {
 							if val == nil {
+								csvdata = append(csvdata, "")
 								continue
 							}
 
 							// this type switch is probably not really needed anymore
 							switch val.(type) {
 							case int64:
-								outdata = fmt.Sprintf("%v", val)
+								outdata = fmt.Sprintf("%d", val)
 							case float64:
-								outdata = fmt.Sprintf("%v", val)
+								f := val.(float64)
+								d := int(f)
+								if f == float64(d) {
+									outdata = fmt.Sprintf("%d", d)
+								} else {
+									outdata = fmt.Sprintf("%f", f)
+								}
+
 							default:
 								outdata = removeLBR(fmt.Sprintf("%v", val))
 							}
 
 							csvdata = append(csvdata, outdata)
+						} else {
+							csvdata = append(csvdata, "")
 						}
 					}
 


### PR DESCRIPTION
For printing the correct numbering format, I use a simple trick to convert the number into int and back to float64, then compare to see if they are the same value.
If yes, then format the value as interger, otherwise as floating number.
For CSV output, we strip off nil values of csvdata, but that cause problem since the structure is changes, and not reflect the CSV header.
So I add the field with append(csvdata, "") for both case.

I also run `go get -u ./...` for updating the dependencies.