### PR TITLE
Add trace flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,27 +17,28 @@ es-query-export -c "http://localhost:9200" -i "logstash-*" --startdate="2019-04-
 
 ## CLI Options
 
-| Flag         | Default               |                | 
-|--------------|-----------------------|----------------|
-| `-h --help`    |                       | show help      |
-| `-v --version` |                       | show version   |
-| `-c --connect` | http://localhost:9200 | URI to ElasticSearch instance  | 
-| `-i --index`   | logs-*                | name of index to use, use globbing characters * to match multiple |
-| `-q --query`   |                       | Lucene query to match documents (same as in Kibana) |
-| `   --fields`  |                       | define a comma separated list of fields to export |
-| `-o --outfile` | output.csv            | name of output file |
-| `-f --outformat` | csv            | format of the output data: possible values csv, json, raw |
-| `-r --rawquery`|                       | optional raw ElasticSearch query JSON string |
-| `-s --start`   |                       | optional start date - Format: YYYY-MM-DDThh:mm:ss.SSSZ. or any other Elasticsearch default format |
-| `-e --end`     |                       | optional end date - Format: YYYY-MM-DDThh:mm:ss.SSSZ. or any other Elasticsearch default format |
-| `--timefield`  |                       | optional time field to use, default to @timestamp |
-| `--verifySSL`  | true                  | optional define how to handle SSL certificates |
-| `--user`       |                       | optional username |
-| `--pass`       |                       | optional password |
-| `--size`       | 1000                  | size of the scroll window, the more the faster the export works but it adds more pressure on your nodes |
+| Flag             | Default               |                                                                                                         | 
+|------------------|-----------------------|---------------------------------------------------------------------------------------------------------|
+| `-h --help`      |                       | show help                                                                                               |
+| `-v --version`   |                       | show version                                                                                            |
+| `-c --connect`   | http://localhost:9200 | URI to ElasticSearch instance                                                                           | 
+| `-i --index`     | logs-*                | name of index to use, use globbing characters * to match multiple                                       |
+| `-q --query`     |                       | Lucene query to match documents (same as in Kibana)                                                     |
+| `   --fields`    |                       | define a comma separated list of fields to export                                                       |
+| `-o --outfile`   | output.csv            | name of output file                                                                                     |
+| `-f --outformat` | csv                   | format of the output data: possible values csv, json, raw                                               |
+| `-r --rawquery`  |                       | optional raw ElasticSearch query JSON string                                                            |
+| `-s --start`     |                       | optional start date - Format: YYYY-MM-DDThh:mm:ss.SSSZ. or any other Elasticsearch default format       |
+| `-e --end`       |                       | optional end date - Format: YYYY-MM-DDThh:mm:ss.SSSZ. or any other Elasticsearch default format         |
+| `--timefield`    |                       | optional time field to use, default to @timestamp                                                       |
+| `--verifySSL`    | true                  | optional define how to handle SSL certificates                                                          |
+| `--user`         |                       | optional username                                                                                       |
+| `--pass`         |                       | optional password                                                                                       |
+| `--size`         | 1000                  | size of the scroll window, the more the faster the export works but it adds more pressure on your nodes |
+| `--trace`        | false                 | enable trace mode to debug queries send to ElasticSearch                                                |
 
 ## Output Formats
 
-- `csv` - all or selected fields separated by comma (,)
+- `csv` - all or selected fields separated by comma (,) with field names in the first line 
 - `json` - all or selected fields as JSON objects, one per line
 - `raw` - JSON dump of matching documents including id, index and _source field containing the document data. One document as JSON object per line.

--- a/export/export.go
+++ b/export/export.go
@@ -43,6 +43,10 @@ func Run(ctx context.Context, conf *flags.Flags) {
 		elastic.SetErrorLog(log.New(os.Stderr, "ELASTIC ", log.LstdFlags)),
 	)
 
+	if conf.Trace {
+		esOpts = append(esOpts, elastic.SetTraceLog(log.New(os.Stderr, "ELASTIC ", log.LstdFlags)))
+	}
+
 	if conf.ElasticUser != "" && conf.ElasticPass != "" {
 		esOpts = append(esOpts, elastic.SetBasicAuth(conf.ElasticUser, conf.ElasticPass))
 	}

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -21,5 +21,6 @@ type Flags struct {
 	ScrollSize       int    `cli:"size" usage:"Number of documents that will be returned per shard"`
 	Timefield        string `cli:"timefield" usage:"Field name to use for start and end date query"`
 	Fieldlist        string `cli:"fields" usage:"Fields to include in export as comma separated list"`
+	Trace            bool   `cli:"trace" usage:"Enable debug output"`
 	Fields           []string
 }


### PR DESCRIPTION
Add a new flag `--trace` that if set to `true` prints out all queries sent to ElasticSearch and the responses to help debugging. 