### PR TITLE
Support stdout output

### DIFF
--- a/export/export.go
+++ b/export/export.go
@@ -61,11 +61,17 @@ func Run(ctx context.Context, conf *flags.Flags) {
 		conf.Fields = strings.Split(conf.Fieldlist, ",")
 	}
 
-	outfile, err := os.Create(conf.Outfile)
-	if err != nil {
-		log.Fatalf("Error creating output file - %s", err)
+	var outfile *os.File
+
+	if conf.Outfile == "-" {
+		outfile = os.Stdout
+	} else {
+		outfile, err = os.Create(conf.Outfile)
+		if err != nil {
+			log.Fatalf("Error creating output file - %s", err)
+		}
+		defer outfile.Close()
 	}
-	defer outfile.Close()
 
 	var rangeQuery *elastic.RangeQuery
 


### PR DESCRIPTION
Send output to stdout if output file is "-" (`-outfile '-'`).

Useful to avoid intermediary temporary files if post-processing is required.

e.g.:

```shell
es-query-export -start="2019-04-04T12:15:00" -q "RequestUri:*export*" -outfile - | aws s3 cp - s3://mybucket/stream.csv
```
