### PR TITLE
Re-initialize document inside hit loop to empty it and not retain old data

### DIFF
--- a/formats/csv.go
+++ b/formats/csv.go
@@ -50,9 +50,9 @@ func (c CSV) Run(ctx context.Context, hits <-chan *elastic.SearchHit) error {
 
 	for i := 0; i < c.Workers; i++ {
 		g.Go(func() error {
-			var document map[string]interface{}
 
 			for hit := range hits {
+				var document map[string]interface{}
 				var csvdata []string
 				var outdata string
 


### PR DESCRIPTION
Because the `document` is initialized currently in L53 and in L59 `json.Unmarshal` is performed and as per Go docs;
> To unmarshal a JSON object into a map, Unmarshal first establishes a map to use. If the map is nil, Unmarshal allocates a new map. Otherwise Unmarshal reuses the existing map, keeping existing entries.
[Source](https://pkg.go.dev/encoding/json#:~:text=To%20unmarshal%20a%20JSON%20object%20into%20a%20map%2C%20Unmarshal%20first%20establishes%20a%20map%20to%20use.%20If%20the%20map%20is%20nil%2C%20Unmarshal%20allocates%20a%20new%20map.%20Otherwise%20Unmarshal%20reuses%20the%20existing%20map%2C%20keeping%20existing%20entries.)

So old data is retained, and this leads to the CSV export being incorrect under certain situations, f.ex. if new document doesn't override all the fields.

To fix, re-initialize document inside the loop rather than outside.