### PR TITLE
Workaround for https://github.com/pteich/elastic-query-export/issues/22

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ var Version string
 func main() {
 	conf := flags.Flags{
 		ElasticURL:       "http://localhost:9200",
-		ElasticVerifySSL: true,
+		ElasticVerifySSL: false,
 		Index:            "logs-*",
 		Query:            "*",
 		OutFormat:        flags.FormatCSV,


### PR DESCRIPTION
Default ElasticVerifySSL to false as command line flag seems only to be able to set option to true.