### PR TITLE
feat: add client cert support

### DIFF
--- a/export/export.go
+++ b/export/export.go
@@ -27,8 +27,21 @@ type Formatter interface {
 
 // Run starts the export of Elastic data
 func Run(ctx context.Context, conf *flags.Flags) {
+	tlsCfg := &tls.Config{
+		InsecureSkipVerify: !conf.ElasticVerifySSL,
+	}
+
+	if conf.ElasticClientCrt != "" && conf.ElasticClientKey != "" {
+		cert, err := tls.LoadX509KeyPair(conf.ElasticClientCrt, conf.ElasticClientKey)
+		if err != nil {
+			log.Fatalf("Error loading client certificate: %s", err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+
+	}
+
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: !conf.ElasticVerifySSL},
+		TLSClientConfig: tlsCfg,
 	}
 	httpClient := &http.Client{Transport: tr}
 

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -11,6 +11,8 @@ type Flags struct {
 	ElasticUser      string `cli:"user" usage:"ElasticSearch Username"`
 	ElasticPass      string `cli:"pass" usage:"ElasticSearch Password"`
 	ElasticVerifySSL bool   `cli:"verifySSL" usage:"Verify SSL certificate"`
+	ElasticClientCrt string `cli:"clientCRT" usage:"Path to client certificate"`
+	ElasticClientKey string `cli:"clientKey" usage:"Path to client certificate key"`
 	Index            string `cli:"index" cliAlt:"i" usage:"ElasticSearch Index (or Index Prefix)"`
 	RAWQuery         string `cli:"rawquery" cliAlt:"r" usage:"ElasticSearch raw query string"`
 	Query            string `cli:"query" cliAlt:"q" usage:"Lucene query same that is used in Kibana search input"`

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func main() {
 		Timefield:        "@timestamp",
 	}
 
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGKILL, syscall.SIGTERM, syscall.SIGINT)
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
 
 	cmd := configstruct.NewCommand(


### PR DESCRIPTION
Elasticsearch (or OpenSearch) can be configured to authenticate via PKI. In this case, sending a client certificate is necessary.